### PR TITLE
Switched GPIO Backend to libgpiod

### DIFF
--- a/octoprint_autoprint/__init__.py
+++ b/octoprint_autoprint/__init__.py
@@ -29,10 +29,15 @@ class AutoprintPlugin(octoprint.plugin.StartupPlugin,
 
     def __init__(self) -> None:
         super().__init__()
+        self._printerControl = None
 
     # ~~ Startup Plugin
 
     def on_after_startup(self):
+        # Another method beat us to it
+        if None != self._printerControl:
+            return
+
         self._printerControl = PrinterControl(self._logger, self._printer)
         self.assignSettings()
         self._autoprinterTimer = AutoPrinterTimer(
@@ -55,6 +60,10 @@ class AutoprintPlugin(octoprint.plugin.StartupPlugin,
         ]
 
     def get_template_vars(self):
+        # Sometimes this gets called before on_after_startup for some reason
+        if None == self._printerControl:
+            self.on_after_startup()
+
         result = dict(
             state=dict(
                 printer=self._printerControl.isPrinterOn,

--- a/octoprint_autoprint/templates/autoprint_settings.jinja2
+++ b/octoprint_autoprint/templates/autoprint_settings.jinja2
@@ -13,17 +13,17 @@
     <div class="control-group">
         <label class="control-label">{{ _('Printer Power') }}</label>
         <div class="controls">
-            <input type="number" class="input-block-level" data-bind="value: settings.settings.plugins.autoprint.gpio.printer">
+            <input class="input-block-level" data-bind="value: settings.settings.plugins.autoprint.gpio.printer">
             <span class="help-inline">
-              GPIO pin (in BCM numbering scheme) of the relais powering the printer</span>
+              GPIO pin of the relais powering the printer. Use gpioinfo to find the name.</span>
         </div>
     </div>
     <div class="control-group">
         <label class="control-label">{{ _('Printer Light') }}</label>
         <div class="controls">
-            <input type="number" class="input-block-level" data-bind="value: settings.settings.plugins.autoprint.gpio.light">
+            <input class="input-block-level" data-bind="value: settings.settings.plugins.autoprint.gpio.light">
             <span class="help-inline">
-              GPIO pin (in BCM numbering scheme) of the relais powering the lights</span>
+              GPIO pin of the relais powering the lights. Use gpioinfo to find the name.</span>
         </div>
     </div>
 

--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,7 @@ plugin_url = "https://github.com/chof747/octoprint-autoprint"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-#plugin_requires = ["RPi.GPIO"]
-
-try:
-    with open('/sys/firmware/devicetree/base/model', 'r') as m:
-        if 'raspberry pi' in m.read().lower(): 
-            plugin_requires = ["RPi.GPIO"]
-        else:
-            plugin_requires = []
-except Exception:
-    plugin_requires = []
+plugin_requires = ["gpiod"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
### :information_source: Info

This one's a bit of a tricky one -- I'm trying to get this up and running on a Beaglebone Black (because Raspberry Pi's are still hard to find). Originally, I was going to make a `[beaglebone]` package option that installs `Adafruit-BBIO` instead of `RPi.BBIO` since they state that they try to make their APIs compatible.

However, `Adafruit-BBIO` doesn't work on my beaglebone. Going a level deeper, even the `/sys/class/gpio` sysfs interface for GPIO just doesn't work anymore. It's there, but it's not hooked up. So, I did some digging, and [apparently the sysfs interface has been deprecated for a while](https://www.kernel.org/doc/Documentation/gpio/sysfs.txt), and has been replaced by a chardev interface backed by `libgpiod`.

This MR lifts the GPIO backend away from the `RPi.GPIO` structure onto the new, platform-agnostic `libgpiod` backend.

As a result, it's no longer really feasible to just choose your backend with a package option. Thankfully, there's really only one breaking change --

### :warning: Breaking Change
The settings structure now relies on pin names instead of BCM numbering. However, this obviously is a breaking change. The motivation here is that BCM isn't really popular on the beaglebone black, because it actually has 4 distinct banks of GPIOs (so a linear numbering scheme like BCM is present, but not as useful). Additionally, the low-level BCM numbers have changed on boards in the past, and with some GPIO pins being dangerous to erroneously write to, I figured the more stable pin naming convention was safer (ie: writing to pin 127 on the beaglebone black may be bad after they rewire things in a future revision. But `P9_11` is documented to be safe, so whatever GPIO line labelled as such should stay safe across future revisions of the same product).

There are a few paths forward that I can come up with:

1. I believe there is an API with Octoprint we can use to invalidate settings on update so that people know they need to re-enter new information. I need to do some digging, but I don't think it's too difficult, but obviously it'll inconvenience everyone currently running this.
2. I can alternatively implement this via BCM numbering, though I'll need a little information from someone with a RPi to make sure I've got the right approach in mind. (I feel more comfortable with naming, but I'm not the maintainer :shrug:)

I'm also open to other options, so please advise on the preferred route forward, and I'll make it work!